### PR TITLE
Add plot_bf, plot_dot, and plot_lm

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -2,4 +2,4 @@
 pandas = ""
 matplotlib = ""
 xarray = ""
-arviz = ">=0.14.0"
+arviz = ">=0.15.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZPythonPlots"
 uuid = "4a6e88f0-2c8e-11ee-0601-e94153f0eada"
 authors = ["Seth Axen <seth@sethaxen.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ArviZ = "131c737c-5715-5e2e-ad31-c244f01c1dc7"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 ArviZ = "131c737c-5715-5e2e-ad31-c244f01c1dc7"
 ArviZExampleData = "2f96bb34-afd9-46ae-bcd0-9b2d4372fe3c"
 ArviZPythonPlots = "4a6e88f0-2c8e-11ee-0601-e94153f0eada"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -122,6 +122,7 @@ using ArviZPythonPlots
 use_style("arviz-darkgrid")
 
 data = randn(1000)
+figure() # hide
 plot_dot(data; dotcolor="C1", point_interval=true)
 title("Gaussian Distribution")
 gcf()

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -17,7 +17,7 @@ See [`plot_autocorr`](@ref)
 ## Bayes Factor Plot
 
 ```@example
-using ArviZPythonPlots
+using ArviZ, ArviZPythonPlots
 
 use_style("arviz-darkgrid")
 
@@ -594,7 +594,7 @@ See [`plot_rank`](@ref)
 ## Regression Plot
 
 ```@example
-using ArviZ, ArviZPythonPlots, ArviZExampleData
+using ArviZ, ArviZPythonPlots, ArviZExampleData, DimensionalData
 
 use_style("arviz-darkgrid")
 
@@ -602,9 +602,7 @@ data = load_example_data("regression1d")
 x = range(0, 1; length=100)
 posterior = data.posterior
 constant_data = convert_to_dataset((; x); default_dims=())
-y_model = broadcast_dims(posterior.intercept, posterior.slope, constant_data.x) do bi, mi, xj
-    mi * xj + bi
-end
+y_model = broadcast_dims(muladd, posterior.intercept, posterior.slope, constant_data.x)
 posterior = merge(posterior, (; y_model))
 data = merge(data, InferenceData(; posterior, constant_data))
 plot_lm("y"; idata=data, x="x", y_model="y_model")

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -668,20 +668,33 @@ style_list = [
     "arviz-darkgrid",
     "arviz-whitegrid",
     "arviz-white",
+    "arviz-grayscale",
+    ["arviz-white", "arviz-redish"],
+    ["arviz-white", "arviz-bluish"],
+    ["arviz-white", "arviz-orangish"],
+    ["arviz-white", "arviz-brownish"],
+    ["arviz-white", "arviz-purplish"],
+    ["arviz-white", "arviz-cyanish"],
+    ["arviz-white", "arviz-greenish"],
+    ["arviz-white", "arviz-royish"],
+    ["arviz-white", "arviz-viridish"],
+    ["arviz-white", "arviz-plasmish"],
+    "arviz-doc",
+    "arviz-docgrid",
 ]
 
-fig = figure(; figsize=(12, 12))
+fig = figure(; figsize=(20, 10))
 for (idx, style) in enumerate(style_list)
-    pywith(pyplot.style.context(style)) do _
-        ax = fig.add_subplot(3, 2, idx; label=idx)
-        for i in 0:9
+    pywith(pyplot.style.context(style; after_reset=true)) do _
+        ax = fig.add_subplot(5, 4, idx; label=idx)
+        colors = pyplot.rcParams["axes.prop_cycle"].by_key()["color"]
+        for i in 0:(length(colors) - 1)
             ax.plot(x, dist .- i, "C$i"; label="C$i")
         end
         ax.set_title(style)
         ax.set_xlabel("x")
         ax.set_ylabel("f(x)"; rotation=0, labelpad=15)
-        ax.legend(; bbox_to_anchor=(1, 1))
-        draw()
+        ax.set_xticklabels([])
     end
 end
 tight_layout()

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -14,6 +14,20 @@ gcf()
 
 See [`plot_autocorr`](@ref)
 
+## Bayes Factor Plot
+
+```@example
+using ArviZPythonPlots
+
+use_style("arviz-darkgrid")
+
+idata = from_namedtuple((a = 1 .+ randn(5_000) ./ 2,), prior=(a = randn(5_000),))
+plot_bf(idata; var_name="a", ref_val=0)
+gcf()
+```
+
+See [`plot_bf`](@ref)
+
 ## Bayesian P-Value Posterior Plot
 
 ```@example
@@ -99,6 +113,36 @@ gcf()
 ```
 
 See [`plot_dist`](@ref)
+
+## Dot Plot
+
+```@example
+using ArviZPythonPlots
+
+use_style("arviz-darkgrid")
+
+data = randn(1000)
+plot_dot(data; dotcolor="C1", point_interval=true)
+title("Gaussian Distribution")
+gcf()
+```
+
+See [`plot_dot`](@ref)
+
+## ECDF Plot
+
+```@example
+using ArviZPythonPlots, Distributions
+
+use_style("arviz-darkgrid")
+
+sample = randn(1_000)
+dist = Normal()
+plot_ecdf(sample; cdf=x -> cdf(dist, x), confidence_bands=true)
+gcf()
+```
+
+See [`plot_ecdf`](@ref)
 
 ## ELPD Plot
 
@@ -546,6 +590,28 @@ gcf()
 ```
 
 See [`plot_rank`](@ref)
+
+## Regression Plot
+
+```@example
+using ArviZ, ArviZPythonPlots, ArviZExampleData
+
+use_style("arviz-darkgrid")
+
+data = load_example_data("regression1d")
+x = range(0, 1; length=100)
+posterior = data.posterior
+constant_data = convert_to_dataset((; x); default_dims=())
+y_model = broadcast_dims(posterior.intercept, posterior.slope, constant_data.x) do bi, mi, xj
+    mi * xj + bi
+end
+posterior = merge(posterior, (; y_model))
+data = merge(data, InferenceData(; posterior, constant_data))
+plot_lm("y"; idata=data, x="x", y_model="y_model")
+gcf()
+```
+
+See [`plot_lm`](@ref)
 
 ## Separation Plot
 

--- a/src/ArviZPythonPlots.jl
+++ b/src/ArviZPythonPlots.jl
@@ -13,29 +13,35 @@ using Tables
 @reexport using PythonPlot
 
 ## Plots
-export plot_autocorr,
-    plot_bpv,
-    plot_compare,
-    plot_density,
-    plot_dist,
-    plot_dist_comparison,
-    plot_elpd,
-    plot_energy,
-    plot_ess,
-    plot_forest,
-    plot_hdi,
-    plot_kde,
-    plot_khat,
-    plot_loo_pit,
-    plot_mcse,
-    plot_pair,
-    plot_parallel,
-    plot_posterior,
-    plot_ppc,
-    plot_rank,
-    plot_separation,
-    plot_trace,
-    plot_violin
+const _PLOT_FUNCTIONS = (
+    :plot_autocorr,
+    :plot_bpv,
+    :plot_compare,
+    :plot_density,
+    :plot_dist,
+    :plot_dist_comparison,
+    :plot_ecdf,
+    :plot_elpd,
+    :plot_energy,
+    :plot_ess,
+    :plot_forest,
+    :plot_hdi,
+    :plot_kde,
+    :plot_khat,
+    :plot_loo_pit,
+    :plot_mcse,
+    :plot_pair,
+    :plot_parallel,
+    :plot_posterior,
+    :plot_ppc,
+    :plot_rank,
+    :plot_separation,
+    :plot_trace,
+    :plot_violin,
+)
+for f in _PLOT_FUNCTIONS
+    @eval export $f
+end
 
 ## rcParams
 export rcParams, rc_context

--- a/src/ArviZPythonPlots.jl
+++ b/src/ArviZPythonPlots.jl
@@ -15,11 +15,13 @@ using Tables
 ## Plots
 const _PLOT_FUNCTIONS = (
     :plot_autocorr,
+    :plot_bf,
     :plot_bpv,
     :plot_compare,
     :plot_density,
     :plot_dist,
     :plot_dist_comparison,
+    :plot_dot,
     :plot_ecdf,
     :plot_elpd,
     :plot_energy,
@@ -28,6 +30,7 @@ const _PLOT_FUNCTIONS = (
     :plot_hdi,
     :plot_kde,
     :plot_khat,
+    :plot_lm,
     :plot_loo_pit,
     :plot_mcse,
     :plot_pair,

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -1,27 +1,7 @@
-@forwardplotfun plot_autocorr
-@forwardplotfun plot_bpv
-@forwardplotfun plot_compare
-@forwardplotfun plot_density
-@forwardplotfun plot_dist
-@forwardplotfun plot_dist_comparison
-@forwardplotfun plot_ecdf
-@forwardplotfun plot_elpd
-@forwardplotfun plot_energy
-@forwardplotfun plot_ess
-@forwardplotfun plot_forest
-@forwardplotfun plot_hdi
-@forwardplotfun plot_kde
-@forwardplotfun plot_khat
-@forwardplotfun plot_loo_pit
-@forwardplotfun plot_mcse
-@forwardplotfun plot_pair
-@forwardplotfun plot_parallel
-@forwardplotfun plot_posterior
-@forwardplotfun plot_ppc
-@forwardplotfun plot_rank
-@forwardplotfun plot_separation
-@forwardplotfun plot_trace
-@forwardplotfun plot_violin
+
+for f in _PLOT_FUNCTIONS
+    @eval @forwardplotfun $f
+end
 
 function convert_arguments(::typeof(plot_elpd), data, args...; kwargs...)
     dict = OrderedDict(

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -13,6 +13,7 @@ end
 
 for f in (
     :plot_autocorr,
+    :plot_bf,
     :plot_ess,
     :plot_mcse,
     :plot_pair,
@@ -32,6 +33,19 @@ end
 function convert_arguments(::typeof(plot_energy), data, args...; kwargs...)
     dataset = convert_to_dataset(data; group=:sample_stats)
     return tuple(dataset, args...), kwargs
+end
+
+function convert_arguments(
+    ::typeof(plot_lm), y, _idata=nothing, args...; idata=nothing, kwargs...
+)
+    if _idata !== nothing
+        idata = convert_to_inference_data(_idata)
+    elseif idata !== nothing
+        idata = convert_to_inference_data(idata)
+    else
+        idata = nothing
+    end
+    return tuple(y, idata, args...), kwargs
 end
 
 for f in (:plot_density, :plot_forest, :plot_rank)

--- a/src/style.jl
+++ b/src/style.jl
@@ -6,8 +6,8 @@ Use matplotlib style settings from a style specification `style`.
 
 The style name of "default" is reserved for reverting back to the default style settings.
 
-ArviZ-specific styles are
-`["arviz-whitegrid", "arviz-darkgrid", "arviz-colors", "arviz-white"]`.
+ArviZ-specific styles include
+`["arviz-whitegrid", "arviz-darkgrid", "arviz-colors", "arviz-white", "arviz-doc"]`.
 To see all available style specifications, use [`styles()`](@ref).
 
 If a `Vector` of styles is provided, they are applied from first to last.

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -1,6 +1,7 @@
 using ArviZ
 using ArviZExampleData
 using ArviZPythonPlots
+using DimensionalData
 using PythonCall
 using Test
 
@@ -50,6 +51,29 @@ using Test
         plot_bpv(data)
         plotclose()
         plot_bpv(data; kind="p_value")
+        plotclose()
+    end
+
+    @testset "plot_bf" begin
+        plot_bf(data; var_name="mu")
+        plotclose()
+    end
+
+    @testset "plot_lm" begin
+        data3 = load_example_data("regression1d")
+        x = range(0, 1; length=100)
+        posterior = data3.posterior
+        constant_data = convert_to_dataset((; x); default_dims=())
+        y_model = broadcast_dims(
+            posterior.intercept, posterior.slope, constant_data.x
+        ) do bi, mi, xj
+            mi * xj + bi
+        end
+        posterior = merge(posterior, (; y_model))
+        data_new = merge(data3, InferenceData(; posterior, constant_data))
+        plot_lm("y"; idata=data_new, x="x", y_model="y_model")
+        plotclose()
+        plot_lm("y", data_new; x="x", y_model="y_model")
         plotclose()
     end
 

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -79,7 +79,7 @@ using Test
         plotclose()
     end
 
-    @testset "$(f)" for f in (plot_dist, ArviZPythonPlots.plot_ecdf)
+    @testset "$(f)" for f in (plot_dist, plot_dot, plot_ecdf)
         f(arr1)
         plotclose()
     end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,5 +1,4 @@
 using ArviZPythonPlots
-using DataFrames: DataFrames
 using PythonCall
 using Test
 


### PR DESCRIPTION
With this PR, we now wrap and export `plot_bf`, `plot_dot`, and `plot_lm`. Additionally, `plot_ecdf`, which was previously wrapped but not exported, is now also exported.