### PR TITLE
Pin Python arviz to v0.15

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -2,4 +2,4 @@
 pandas = ""
 matplotlib = ""
 xarray = ""
-arviz = ">=0.15.0"
+arviz = ">=0.15.0,<0.16.0"


### PR DESCRIPTION
AutoMerge on the general registry seems to hit a an error when loading the package. This PR tries to fix this by bounding arviz to below v0.16.0, following https://github.com/arviz-devs/arviz/issues/2274#issuecomment-1674120357