### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1", "1.8", "nightly"]
-        os: [ubuntu-latest]
+        julia-version: ["1"]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
-          - julia-version: "1"
-            os: windows-latest
-          - julia-version: "1"
-            os: macOS-latest
+          - julia-version: "1.8"
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZPythonPlots"
 uuid = "4a6e88f0-2c8e-11ee-0601-e94153f0eada"
 authors = ["Seth Axen <seth@sethaxen.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 ArviZ = "131c737c-5715-5e2e-ad31-c244f01c1dc7"

--- a/test/test_xarray.jl
+++ b/test/test_xarray.jl
@@ -19,7 +19,9 @@ using Test
         @test o isa Py
         @test pyisinstance(o, ArviZPythonPlots.xarray.Dataset)
 
-        @test issetequal(Symbol.(o.coords.keys()), (:chain, :draw, :shared, :ydim1))
+        @test issetequal(
+            Symbol.(collect(o.coords.keys())), (:chain, :draw, :shared, :ydim1)
+        )
         for (dim, coord) in o.coords.items()
             @test pyeq(
                 Bool, pylist(coord.values), pylist(DimensionalData.index(ds, Symbol(dim)))


### PR DESCRIPTION
PythonCall [v0.9.16](https://github.com/JuliaPy/PythonCall.jl/releases/tag/v0.9.16) made some changes that broke a line of code in our CI. This fixes that line. Also, since CI has never passed for Julia nightly due to micromamba set-up issues, this PR removes it from CI.