### PR TITLE
Bump compat for ArviZ v0.12 and DimensionalData v0.27

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZPythonPlots"
 uuid = "4a6e88f0-2c8e-11ee-0601-e94153f0eada"
 authors = ["Seth Axen <seth@sethaxen.com>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 ArviZ = "131c737c-5715-5e2e-ad31-c244f01c1dc7"

--- a/Project.toml
+++ b/Project.toml
@@ -15,10 +15,10 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-ArviZ = "0.10, 0.11"
+ArviZ = "0.10, 0.11, 0.12"
 ArviZExampleData = "0.1.5"
 CondaPkg = "0.2"
-DimensionalData = "0.23, 0.24, 0.25, 0.26"
+DimensionalData = "0.23, 0.24, 0.25, 0.26, 0.27"
 Markdown = "1.6"
 OrderedCollections = "1"
 PythonCall = "0.9"


### PR DESCRIPTION
Locally I have confirmed that tests pass for these versions (ArviZ v0.12 is not yet released).