### PR TITLE
Stop running CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ["1"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
         include:
           - julia-version: "1.8"
             os: ubuntu-latest


### PR DESCRIPTION
This has never once passed, and it's not at all clear why, so it just wastes compute and creates notification noise.