### PR TITLE
chore: Remove DimensionalData v0.29.25 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 ArviZExampleData = "0.1.5"
 CondaPkg = "0.2"
-DimensionalData = "0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29.1-0.29.4, 0.29.6-0.29.24, 0.29.26-0.29"
+DimensionalData = "0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29.1 - 0.29.4, 0.29.6 - 0.29.24, ~0.29.26"
 InferenceObjects = "0.4.13"
 Markdown = "1"
 OrderedCollections = "1"


### PR DESCRIPTION
This PR just yanks support for DimensionalData v0.29.25 using version inequality bounds.

DimensionalData v0.29.25 added in rafaqz/DimensionalData.jl#1109 a Python version bound to v3.13 in its global `CondaPkg.toml`, which is incompatible with arviz. The global `CondaPkg.toml` has since been removed, but since this change has not been released, this is causing all CI using this package to fail.