### PR TITLE
ci: Use default architecture for all runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: x64
       - uses: julia-actions/cache@v2
       - name: Cache CondaPkg
         id: cache-condaPkg


### PR DESCRIPTION
The default architecture for a MacOS runner on GitHub Actions is now `aarch64`, while we're forcing `64`. Since we're not testing on multiple runners anyways, this PR removes the arch specifier so that we use the default for each runner.