### PR TITLE
ci: Downgrade checkout action from v6 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - julia-version: "1"
             os: macOS-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}


### PR DESCRIPTION
This is just to check if the macos build then passes.