### PR TITLE
docs: drop conflicting ms kwarg from ESS local plot example

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -196,7 +196,7 @@ using ArviZPythonPlots, ArviZExampleData
 use_style("arviz-darkgrid")
 
 idata = load_example_data("non_centered_eight")
-plot_ess(idata; var_names=["mu"], kind="local", marker="_", ms=20, mew=2, rug=true)
+plot_ess(idata; var_names=["mu"], kind="local", marker="_", mew=2, rug=true)
 gcf()
 ```
 


### PR DESCRIPTION
The ESS local plot example in docs/src/examples.md fails to build: `Got both 'ms' and 'markersize', which are aliases of one another`. This plot kind apparently sets markersize internally, and a recent matplotlib version started hard-erroring on the duplicate alias instead of silently resolving it. Drops the redundant `ms=20` from the example call.