### PR TITLE
build(docs): add missing compat bounds for package deps

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,7 +11,10 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 ArviZPythonPlots = {path = ".."}
 
 [compat]
-ArviZ = "0.13"
-ArviZExampleData = "0.1.5"
+ArviZ = "0.14"
+ArviZExampleData = "0.3"
+ArviZPythonPlots = "0.1.13"
+DimensionalData = "0.29"
 Distributions = "0.25"
 Documenter = "1"
+PythonCall = "0.9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,7 +12,7 @@ ArviZPythonPlots = {path = ".."}
 
 [compat]
 ArviZ = "0.14"
-ArviZExampleData = "0.3"
+ArviZExampleData = "0.2"
 ArviZPythonPlots = "0.1.13"
 DimensionalData = "0.29"
 Distributions = "0.25"


### PR DESCRIPTION
## Summary
- Add missing `[compat]` entries in `docs/Project.toml` for `ArviZPythonPlots`, `DimensionalData`, and `PythonCall`, which are already deps with bounds declared in the root `Project.toml`
- Bump `ArviZ` compat to its latest version, since docs builds don't need to support old releases
- Pin `ArviZExampleData` to `0.2` for now — `0.3` drops datasets our examples still use; bumping further needs example updates first

## Context
Dependabot PR #78 adds these same entries but pins them to the exact currently-resolved version rather than a real bound, and mixes them with legitimate dependency bumps to root `Project.toml`. This PR adds the entries directly so #78 can rebase down to just the real version bumps.

## Test plan
- [x] `julia --project=docs -e 'using Pkg; Pkg.update()'` resolves cleanly with no conflicts