### PR TITLE
ci: add Downgrade workflow

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,44 @@
+name: Downgrade
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Downgrade / Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ["lts"]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v3
+      - name: Cache CondaPkg
+        id: cache-condaPkg
+        uses: actions/cache@v6
+        env:
+          cache-name: cache-condapkg
+        with:
+          path: .CondaPkg
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('docs/CondaPkg.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          mode: deps
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v7
+        with:
+          fail_ci_if_error: false


### PR DESCRIPTION
Adds a separate Downgrade workflow that tests against dependencies downgraded to their floor versions (mode: deps) on Julia lts, matching the rest of the fleet.